### PR TITLE
Update dependencies to latest stable versions

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,11 +10,11 @@
   :dependencies
   [[org.clojure/clojure "1.10.3"]
    [mvxcvi/alphabase "2.1.1"]
-   [manifold "0.2.3"]]
+   [manifold "0.2.4"]]
 
   :profiles
   {:repl
    {:source-paths ["dev"]
     :jvm-opts ["-XX:-OmitStackTraceInFastThrow"]
     :dependencies
-    [[org.clojure/tools.namespace "1.2.0"]]}})
+    [[org.clojure/tools.namespace "1.3.0"]]}})


### PR DESCRIPTION
This PR updates `ken`'s dependencies as revealed through `lein ancient` (sans `org.clojure/clojure`):

```
[manifold "0.2.4"] is available but we use "0.2.3"
[org.clojure/tools.namespace "1.3.0"] is available but we use "1.2.0"
```

Release version 1.0.2 will follow this upon merge.