### PR TITLE
OpenTelemetry traceparent header

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
       - run:
           name: Install clj-kondo
           environment:
-            CLJ_KONDO_VERSION: 2021.04.23
+            CLJ_KONDO_VERSION: 2022.11.02
           command: |
             wget https://github.com/borkdude/clj-kondo/releases/download/v${CLJ_KONDO_VERSION}/clj-kondo-${CLJ_KONDO_VERSION}-linux-amd64.zip
             unzip clj-kondo-${CLJ_KONDO_VERSION}-linux-amd64.zip

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,10 +1,18 @@
-{:linters {:consistent-alias
-           {:level :warning
-            :aliases {clojure.java.io io
-                      clojure.spec.alpha s
-                      clojure.set set
-                      clojure.string str
-                      manifold.deferred d}}
+{:linters
+ {:consistent-alias
+  {:level :warning
+   :aliases {clojure.java.io io
+             clojure.spec.alpha s
+             clojure.set set
+             clojure.string str
+             manifold.deferred d}}
 
-           :unresolved-symbol
-           {:exclude [(ken.core-test/capture-observed [observed])]}}}
+  :unresolved-symbol
+  {:exclude [(ken.core-test/capture-observed [observed])]}
+
+  :deprecated-var
+  {:exclude
+   {ken.trace/format-header
+    {:namespaces [ken.trace-test]}
+    ken.trace/parse-header
+    {:namespaces [ken.trace-test]}}}}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+This release has **potentially breaking changes** if you have a dependency on
+the specific format of the trace and span identifiers. These changes move ken
+more in line with the [OpenTelemetry](https://opentelemetry.io/) standard to
+improve interoperability.
+
+### Changed
+- Trace identifiers are now 16 bytes of hexadecimal (previously they were 12
+  bytes of base32). Span identifiers are now 8 bytes of hex (previously 6 bytes
+  of base32).
+  [#3](https://github.com/amperity/ken/pull/3)
+
+
 ## [1.0.2] - 2022-05-27
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ improve interoperability.
   of base32).
   [#3](https://github.com/amperity/ken/pull/3)
 
+### Added
+- A new set of functions in `ken.trace` contain logic for working with the OTel
+  `traceparent` header instead of the custom `X-Ken-Trace` header. The previous
+  functions are now deprecated.
+  [#4](https://github.com/amperity/ken/pull/4)
+
 
 ## [1.0.2] - 2022-05-27
 


### PR DESCRIPTION
This follows up #3 to add support for the `traceparent` header defined in the OpenTelemetry [Trace Context](https://www.w3.org/TR/trace-context/) spec. Ultimately, this will replace ken's home-grown `X-Ken-Trace` header. The old functions still exist, but are marked for deprecation. The old parsing function will parse the new format for backwards compatibility.

## Changes
- Update `clj-kondo` version and config.
- Add new `parent-header-name` var, `format-parent-header`, and `parse-parent-header` functions.
- Deprecate the old header functions.
- Add tests.