### PR TITLE
Remove Manifold dependency

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -15,8 +15,4 @@
    {ken.trace/format-header
     {:namespaces [ken.trace-test]}
     ken.trace/parse-header
-    {:namespaces [ken.trace-test]}}}}
-
- :config-in-call
- {ken.util/when-manifold
-  {:linters {:unresolved-namespace {:exclude [d]}}}}}
+    {:namespaces [ken.trace-test]}}}}}

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -15,4 +15,8 @@
    {ken.trace/format-header
     {:namespaces [ken.trace-test]}
     ken.trace/parse-header
-    {:namespaces [ken.trace-test]}}}}}
+    {:namespaces [ken.trace-test]}}}}
+
+ :config-in-call
+ {ken.util/when-manifold
+  {:linters {:unresolved-namespace {:exclude [d]}}}}}

--- a/bin/repl
+++ b/bin/repl
@@ -3,4 +3,4 @@
 
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
-exec clj -M:repl "$@"
+exec clj -M:manifold:repl "$@"

--- a/bin/test
+++ b/bin/test
@@ -7,7 +7,7 @@ if [[ $1 = check ]]; then
     exec clojure -M:check
 elif [[ $1 = coverage ]]; then
     shift
-    exec clojure -M:coverage "$@"
+    exec clojure -M:manifold:coverage "$@"
 else
-    exec clojure -M:test "$@"
+    exec clojure -M:manifold:test "$@"
 fi

--- a/deps.edn
+++ b/deps.edn
@@ -12,7 +12,6 @@
           io.github.slipset/deps-deploy {:git/sha "07022b92d768590ab25b9ceb619ef17d2922da9a"}}
    :ns-default build}
 
-
   :manifold
   {:extra-deps {manifold/manifold {:mvn/version "0.4.3"}}}
 

--- a/deps.edn
+++ b/deps.edn
@@ -2,9 +2,8 @@
  ["src"]
 
  :deps
- {org.clojure/clojure {:mvn/version "1.11.1"}
-  mvxcvi/alphabase {:mvn/version "2.1.1"}
-  manifold/manifold {:mvn/version "0.4.3"}}
+ {org.clojure/clojure {:mvn/version "1.11.3"}
+  mvxcvi/alphabase {:mvn/version "2.1.1"}}
 
  :aliases
  {:build
@@ -13,6 +12,9 @@
           io.github.slipset/deps-deploy {:git/sha "07022b92d768590ab25b9ceb619ef17d2922da9a"}}
    :ns-default build}
 
+
+  :manifold
+  {:extra-deps {manifold/manifold {:mvn/version "0.4.3"}}}
 
   :repl
   {:extra-paths ["dev" "test"]

--- a/src/ken/util.clj
+++ b/src/ken/util.clj
@@ -1,6 +1,7 @@
 (ns ^:no-doc ken.util
   "Utilities for the observability code."
   (:import
+    clojure.lang.Var
     (java.util.concurrent
       CompletionStage)
     (java.util.function
@@ -21,18 +22,6 @@
     (delay (/ (- (System/nanoTime) start) 1e6))))
 
 
-(defmacro ^:private when-manifold
-  "Evaluates forms in `body` if `manifold` is available, otherwise evaluates to
-  nil. The deferred ns is aliased as `d` for convenience."
-  [& body]
-  (when (try
-          (require '[manifold.deferred :as d])
-          true
-          (catch Exception _
-            false))
-    `(do ~@body)))
-
-
 (defn wrap-finally
   "Ensure the function `f` is run after the body run by `body-fn` completes. If
   `body-fn` returns an asynchronous value, `f` will run once it is realized."
@@ -49,34 +38,20 @@
         (final)
         (throw err))
 
-      ;; A manifold deferred value was returned. We need to ensure that
-      ;; when the deferred is realized, the thread that delivers its value to
-      ;; any chained callbacks retains the _original_ bindings from the context
-      ;; where `wrap-finally` was called. Without this logic the trace bindings
-      ;; wind up getting propagated incorrectly to chained functions.
-      (when-manifold
-        (d/deferred? result))
-      (when-manifold
-        (let [d' (d/deferred)]
-          (d/on-realized
-            result
-            (bound-fn bound-success
-              [x]
-              (d/success! d' x))
-            (bound-fn bound-error
-              [e]
-              (d/error! d' e)))
-          (d/finally d' final)))
-
       ;; A native Java async stage was returned, so attach a when-complete
-      ;; callback to execute the final logic.
+      ;; callback to execute the final logic. We also need to ensure that any
+      ;; further callbacks operate with the same thread bindings as the
+      ;; location `wrap-finally` was invoked. Without this logic the trace
+      ;; bindings may be propagated incorrectly to chained functions.
       (instance? CompletionStage result)
-      (let [stage ^CompletionStage result]
+      (let [stage ^CompletionStage result
+            bindings (Var/getThreadBindingFrame)]
         (.whenComplete
           stage
           (reify BiConsumer
             (accept
               [_ _ _]
+              (Var/resetThreadBindingFrame bindings)
               (final)))))
 
       ;; A value was returned synchronously, so invoke `final` and return.

--- a/test/ken/core_test.clj
+++ b/test/ken/core_test.clj
@@ -230,26 +230,30 @@
   ;; hierarchies in manifold. Making `then` a `bound-fn` fixes this problem,
   ;; but ideally this should just work correctly out of the box.
   (capture-observed
-    @(ken/watch "top"
-       (d/chain
-         ;; A watch macro is wrapped around a future computation, which captures
-         ;; its thread bindings.
-         (ken/watch "one"
-           (d/future
-             ;; The forms evaluated here know they are in span 'one' from the
-             ;; dynamic trace context.
-             1))
-         ;; In manifold, the thread which completes a deferred that has chained
-         ;; computations is also responsible for invoking those callbacks. This
-         ;; function gets called by the `d/future` above.
-         (fn then
-           [x]
-           ;; At this point, the future _still has the thread bindings from
-           ;; span one_, which means that - without further machinery - span
-           ;; 'two' here will appear to be a child of 'one', rather than a
-           ;; sibling. This is wrong.
-           (ken/watch "two"
-             (inc x)))))
+    (let [gate (promise)
+          work (ken/watch "top"
+                 (d/chain
+                   ;; A watch macro is wrapped around a future computation, which captures
+                   ;; its thread bindings.
+                   (ken/watch "one"
+                     (d/future
+                       ;; The forms evaluated here know they are in span 'one' from the
+                       ;; dynamic trace context.
+                       @gate
+                       1))
+                   ;; In manifold, the thread which completes a deferred that has chained
+                   ;; computations is also responsible for invoking those callbacks. This
+                   ;; function gets called by the `d/future` above.
+                   (fn then
+                     [x]
+                     ;; At this point, the future _still has the thread bindings from
+                     ;; span one_, which means that - without further machinery - span
+                     ;; 'two' here will appear to be a child of 'one', rather than a
+                     ;; sibling. This is wrong.
+                     (ken/watch "two"
+                       (inc x)))))]
+      (deliver gate :go)
+      (is (= 2 @work)))
     (is (= 3 (count @observed)))
     (is (= ["one" "two" "top"]
            (map ::event/label @observed)))

--- a/test/ken/core_test.clj
+++ b/test/ken/core_test.clj
@@ -225,6 +225,49 @@
             "inner span inherits sampling decision")))))
 
 
+(deftest manifold-trace-propagation
+  ;; This test covers a specific issue that can cause incorrect span
+  ;; hierarchies in manifold. Making `then` a `bound-fn` fixes this problem,
+  ;; but ideally this should just work correctly out of the box.
+  (capture-observed
+    @(ken/watch "top"
+       (d/chain
+         ;; A watch macro is wrapped around a future computation, which captures
+         ;; its thread bindings.
+         (ken/watch "one"
+           (d/future
+             ;; The forms evaluated here know they are in span 'one' from the
+             ;; dynamic trace context.
+             1))
+         ;; In manifold, the thread which completes a deferred that has chained
+         ;; computations is also responsible for invoking those callbacks. This
+         ;; function gets called by the `d/future` above.
+         (fn then
+           [x]
+           ;; At this point, the future _still has the thread bindings from
+           ;; span one_, which means that - without further machinery - span
+           ;; 'two' here will appear to be a child of 'one', rather than a
+           ;; sibling. This is wrong.
+           (ken/watch "two"
+             (inc x)))))
+    (is (= 3 (count @observed)))
+    (is (= ["one" "two" "top"]
+           (map ::event/label @observed)))
+    (let [[one two top] @observed]
+      (is (= (::trace/trace-id top)
+             (::trace/trace-id one))
+          "first child span should belong to same trace")
+      (is (= (::trace/trace-id top)
+             (::trace/trace-id two))
+          "second child span should belong to same trace")
+      (is (= (::trace/span-id top)
+             (::trace/parent-id one))
+          "first child should have top as parent")
+      (is (= (::trace/span-id top)
+             (::trace/parent-id two))
+          "second child should have top as parent"))))
+
+
 (deftest annotations
   (testing "annotate"
     (testing "with bad arguments"


### PR DESCRIPTION
The [manifold](https://github.com/clj-commons/manifold/) library is a great async abstraction layer, but not every client who wants to use `ken` will be using manifold, and it'd be nice to not have to pull it into their dependency closures. There's a pretty simple pattern for doing this in Clojure, which is to test for a namespace existing at compile-time using a macro.

Interestingly, as of 0.4.x, manifold `Deferred` values also implement `CompletionStage`, so the generic code path in #8 would also work without any dependency at all! Unfortunately, there's one particular implementation wrinkle in manifold that causes very unintuitive behavior when used with `ken/watch` in a certain way. There's a simple fix for this using `bound-fn` wrappers, but we do need manifold-specific logic to do so. I added a new test with extensive comments to ensure that this doesn't regress.

Update: after further experimentation and consulting the ~ancient scrolls~ source code, I found a way to effectively mimic what the manifold callbacks were doing using Clojure's `Var` manipulation directly. 🧙‍♂️ 