### PR TITLE
Remove clojure.spec in favor of plain data schemas

### DIFF
--- a/src/ken/trace.cljc
+++ b/src/ken/trace.cljc
@@ -22,28 +22,30 @@
   (:require
     [alphabase.bytes :as b]
     [alphabase.hex :as hex]
-    [clojure.spec.alpha :as s]
     [clojure.string :as str]
     [ken.event :as event]))
 
 
-;; ## Trace Attributes
+(def schemas
+  "Event attributes for trace information as Malli-compatible schemas."
+  {;; Unique identifier for the overall trace of all linked events.
+   ::trace-id
+   :string
 
-;; Unique identifier for the overall trace of all linked events.
-(s/def ::trace-id string?)
+   ;; Identifier for this specific span event.
+   ::span-id
+   :string
+
+   ;; Identifier for the parent of this span.
+   ::parent-id
+   :string
+
+   ;; A boolean to represent a sampling decision.
+   ::keep?
+   :boolean})
 
 
-;; Identifier for this specific span event.
-(s/def ::span-id string?)
-
-
-;; Identifier for the parent of this span.
-(s/def ::parent-id string?)
-
-
-;; A boolean to represent a sampling decision.
-(s/def ::keep? boolean?)
-
+;; ## Trace Identifiers
 
 (defn- gen-id
   "Generate a new trace or span identifier with `n` bytes of entropy."


### PR DESCRIPTION
This PR removes references to `clojure.spec.alpha` from the code. Previously we have used this to define what the expected shape of a ken event looks like, but nowhere do we actually perform validation using these specs. In contexts which perform dead code elimination such as ClojureScript advanced compilation and GraalVM native-image builds, using spec's `s/def` causes global side effects which wind up pulling in all of spec's implementation.

Instead, let's keep the attribute definitions for documentation purposes, but express them as "plain data" schemas which can be used with [malli](https://github.com/metosin/malli) if programmatic validation is desirable. If the new schema vars are not referenced by clients, they too will simply be eliminated as more dead code without pulling anything else in.

A side-effect of this change is that any clients which were performing `s/keys` validation using `clojure.spec` on maps which have `:ken.event/*` and `:ken.trace/*` entries will **no longer validate the values** against the schemas here. I think this is a worthwhile tradeoff for a less opinionated library that behaves better in builds.