### PR TITLE
Fix thread-binding issue with Manifold

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
       - run:
           name: Install clj-kondo
           environment:
-            CLJ_KONDO_VERSION: 2022.11.02
+            CLJ_KONDO_VERSION: 2025.02.20
           command: |
             wget https://github.com/borkdude/clj-kondo/releases/download/v${CLJ_KONDO_VERSION}/clj-kondo-${CLJ_KONDO_VERSION}-linux-amd64.zip
             unzip clj-kondo-${CLJ_KONDO_VERSION}-linux-amd64.zip
@@ -32,10 +32,11 @@ jobs:
       - run:
           name: Install cljstyle
           environment:
-            CLJSTYLE_VERSION: 0.15.0
+            CLJSTYLE_VERSION: 0.17.642
+            CLJSTYLE_PLATFORM: linux_amd64
           command: |
-            wget https://github.com/greglook/cljstyle/releases/download/${CLJSTYLE_VERSION}/cljstyle_${CLJSTYLE_VERSION}_linux.zip
-            unzip cljstyle_${CLJSTYLE_VERSION}_linux.zip
+            wget https://github.com/greglook/cljstyle/releases/download/${CLJSTYLE_VERSION}/cljstyle_${CLJSTYLE_VERSION}_${CLJSTYLE_PLATFORM}.zip
+            unzip cljstyle_${CLJSTYLE_VERSION}_${CLJSTYLE_PLATFORM}.zip
       - run:
           name: Check source formatting
           command: "./cljstyle check --report"

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,16 @@
-/target
+# Development tooling
 /.idea
 *.iml
+.nrepl-port
+
+# Dependencies and caches
+/.cpcache
+/.clj-kondo/inline-configs
+/.clj-kondo/.lock
+/.clj-kondo/.cache
+
+# Build outputs
+/target
 *.jar
 *.class
 *.asc
-.lein-*
-.nrepl-port
-.clj-kondo/.cache
-.cpcache

--- a/deps.edn
+++ b/deps.edn
@@ -31,7 +31,8 @@
 
   :test
   {:extra-paths ["test"]
-   :extra-deps {lambdaisland/kaocha {:mvn/version "1.91.1392"}}
+   :extra-deps {lambdaisland/kaocha {:mvn/version "1.91.1392"}
+                org.slf4j/slf4j-simple {:mvn/version "2.0.17"}}
    :jvm-opts ["-XX:-OmitStackTraceInFastThrow"]
    :main-opts ["-m" "kaocha.runner"]}
 

--- a/dev/ken/repl.clj
+++ b/dev/ken/repl.clj
@@ -8,4 +8,5 @@
     [ken.event :as event]
     [ken.tap :as tap]
     [ken.trace :as trace]
+    [ken.util :as ku]
     [manifold.deferred :as d]))

--- a/src/ken/util.clj
+++ b/src/ken/util.clj
@@ -3,6 +3,7 @@
   (:import
     clojure.lang.Var
     (java.util.concurrent
+      CompletableFuture
       CompletionStage)
     (java.util.function
       BiConsumer)))
@@ -56,43 +57,84 @@
     (flush)))
 
 
+(defmacro ^:private when-manifold
+  "Compile-time support for the manifold async library. Returns nil if manifold
+  is not available."
+  [& body]
+  (try
+    (require 'manifold.deferred)
+    `(do ~@body)
+    (catch Exception _
+      nil)))
+
+
 (defn wrap-finally
   "Ensure the function `f` is run after the body run by `body-fn` completes. If
-  `body-fn` returns an asynchronous value, `f` will run once it is realized."
+  `body-fn` returns an asynchronous value that supports callbacks, `f` will run
+  once it is realized. `f` must not throw exceptions."
   [body-fn f]
-  (let [final (bound-fn* f)
-        [result err] (try
+  (let [[result err] (try
                        [(body-fn) nil]
                        (catch Exception ex
                          [nil ex]))]
     (cond
-      ;; An error was thrown synchronously, so invoke `final` and re-throw.
+      ;; An error was thrown synchronously, so invoke `f` and re-throw.
       err
       (do
-        (final)
+        (f)
         (throw err))
 
-      ;; A native Java async stage was returned, so attach a when-complete
-      ;; callback to execute the final logic. We also need to ensure that any
-      ;; further callbacks operate with the same thread bindings as the
-      ;; location `wrap-finally` was invoked. Without this logic the trace
+      ;; A manifold deferred value was returned, so construct a new deferred value
+      ;; that the final logic can be triggered from. We also need to ensure
+      ;; that any further callbacks operate with the same thread bindings as
+      ;; the location `wrap-finally` was invoked. Without this logic the trace
       ;; bindings may be propagated incorrectly to chained functions.
+      (when-manifold
+        (manifold.deferred/deferred? result))
+      (when-manifold
+        (let [ret (manifold.deferred/deferred)]
+          (manifold.deferred/on-realized
+            result
+            (bound-fn bound-success
+              [x]
+              (f)
+              (manifold.deferred/success! ret x))
+            (bound-fn bound-error
+              [ex]
+              (f)
+              (manifold.deferred/error! ret ex)))
+          ret))
+
+      ;; A Java async stage or completable future was returned, so attach a
+      ;; callback to execute the final logic. As above, this needs to propagate
+      ;; thread bindings.
       (instance? CompletionStage result)
-      ;; FIXME: this is the wrong approach
-      (let [stage ^CompletionStage result
-            bindings (Var/getThreadBindingFrame)]
+      (let [bindings (get-thread-bindings)
+            cf ^CompletableFuture (if (instance? CompletableFuture result)
+                                    (.newIncompleteFuture ^CompletableFuture result)
+                                    (CompletableFuture.))]
         (.whenComplete
-          stage
+          ^CompletionStage result
           (reify BiConsumer
             (accept
-              [_ _ _]
-              (debug-thread-bindings "in whenComplete BiConsumer")
-              (Var/resetThreadBindingFrame bindings)
-              (final)
-              (debug-thread-bindings "did whenComplete BiConsumer")))))
+              [_ value ex]
+              (push-thread-bindings bindings)
+              (try
+                (f)
+                (if ex
+                  (.completeExceptionally cf ex)
+                  (.complete cf value))
+                (finally
+                  (pop-thread-bindings))))))
+        cf)
 
-      ;; A value was returned synchronously, so invoke `final` and return.
+      ;; NOTE: if a regular old `future` was returned, we could wrap it in
+      ;; another thread waiting for it to complete, but that seems like it
+      ;; would be a pretty surprising resource allocation for an observability
+      ;; library to make. Maybe reconsider when virtual threads are the norm?
+
+      ;; A value was returned synchronously, so invoke `f` and return.
       :else
       (do
-        (final)
+        (f)
         result))))

--- a/test/ken/core_test.clj
+++ b/test/ken/core_test.clj
@@ -304,6 +304,7 @@
                       (debug-thread-bindings "bound-error" e)
                       (d/error! d2 e)))
                   (let [d3 (ken/watch "work"
+                             (debug-thread-bindings "in work span")
                              d2)]
                     (debug-thread-bindings "did work span")
                     (deliver container d3))
@@ -323,14 +324,14 @@
                 (try
                   @gate
                   (debug-thread-bindings "in test-thread-2")
-                  ;; TODO: this should be throwing :psyduck:
-                  (let [ret (d/success! d1 :result)]
-                    (debug-thread-bindings "success d1" ret)
-                    (report*
-                      {:type (if (true? ret) :pass :fail)
-                       :message "Should deliver result to core deferred"
-                       :expected true
-                       :actual ret}))
+                  (binding []
+                    (let [ret (d/success! d1 :result)]
+                      (debug-thread-bindings "success d1" ret)
+                      (report*
+                        {:type (if (true? ret) :pass :fail)
+                         :message "Should deliver result to core deferred"
+                         :expected true
+                         :actual ret})))
                   (catch Exception ex
                     (debug-thread-bindings "exception" ex)
                     (report*
@@ -359,7 +360,6 @@
               (is (= :result result))))))
       (is (= 1 (count @observed)))
       (prn @observed)
-      (is false)
       ,,,)))
 
 


### PR DESCRIPTION
This PR addresses a fairly complex thread-binding frame issue that came up with Manifold and certain access patterns for the asynchronous call path in `ken.core/watch`. See the referenced issue for a deeper analysis.

Fixes #11 