### PR TITLE
Rename ::event/sample-rate to ::trace/upstream-sampling in `maybe-sample`

### DIFF
--- a/src/ken/trace.cljc
+++ b/src/ken/trace.cljc
@@ -142,7 +142,7 @@
   "Apply sampling logic to the event, returning an updated event map."
   [event]
   (cond
-    ;; Sampling decision has already been made, so disregard any sample rate.
+    ;; Sampling decision has already been made, rename to :ken.trace/upstream-sampling
     (some? (::keep? event))
     (if-let [sample-rate (::event/sample-rate event)]
       (-> (dissoc event ::event/sample-rate)

--- a/src/ken/trace.cljc
+++ b/src/ken/trace.cljc
@@ -124,7 +124,9 @@
      (when-let [parent-id (::span-id data)]
        {::parent-id parent-id})
      (when-some [keep? (::keep? data)]
-       {::keep? keep?}))))
+       {::keep? keep?})
+     (when-some [sample-rate (::sample-rate data)]
+       {::sample-rate sample-rate}))))
 
 
 ;; ## Sampling Logic
@@ -142,7 +144,10 @@
   (cond
     ;; Sampling decision has already been made, so disregard any sample rate.
     (some? (::keep? event))
-    (dissoc event ::event/sample-rate)
+    (if-let [sample-rate (::event/sample-rate event)]
+      (-> (dissoc event ::event/sample-rate)
+          (assoc ::sample-rate sample-rate))
+      event)
 
     ;; Sample rate is set without decision, so randomly sample. In the case
     ;; where we decide to keep the event, _do not_ set `::keep?` so that

--- a/src/ken/trace.cljc
+++ b/src/ken/trace.cljc
@@ -125,8 +125,8 @@
        {::parent-id parent-id})
      (when-some [keep? (::keep? data)]
        {::keep? keep?})
-     (when-some [sample-rate (::upstream-sample-rate data)]
-       {::upstream-sample-rate sample-rate}))))
+     (when-some [sample-rate (::upstream-sampling data)]
+       {::upstream-sampling sample-rate}))))
 
 
 ;; ## Sampling Logic
@@ -146,7 +146,7 @@
     (some? (::keep? event))
     (if-let [sample-rate (::event/sample-rate event)]
       (-> (dissoc event ::event/sample-rate)
-          (assoc ::upstream-sample-rate sample-rate))
+          (assoc ::upstream-sampling sample-rate))
       event)
 
     ;; Sample rate is set without decision, so randomly sample. In the case

--- a/src/ken/trace.cljc
+++ b/src/ken/trace.cljc
@@ -125,8 +125,8 @@
        {::parent-id parent-id})
      (when-some [keep? (::keep? data)]
        {::keep? keep?})
-     (when-some [sample-rate (::sample-rate data)]
-       {::sample-rate sample-rate}))))
+     (when-some [sample-rate (::upstream-sample-rate data)]
+       {::upstream-sample-rate sample-rate}))))
 
 
 ;; ## Sampling Logic
@@ -146,7 +146,7 @@
     (some? (::keep? event))
     (if-let [sample-rate (::event/sample-rate event)]
       (-> (dissoc event ::event/sample-rate)
-          (assoc ::sample-rate sample-rate))
+          (assoc ::upstream-sample-rate sample-rate))
       event)
 
     ;; Sample rate is set without decision, so randomly sample. In the case

--- a/test/ken/trace_test.clj
+++ b/test/ken/trace_test.clj
@@ -41,11 +41,13 @@
       (is (= {::trace/trace-id "trace123"
               ::trace/parent-id "span456"
               ::trace/span-id "span789"
-              ::trace/keep? false}
+              ::trace/keep? false
+              ::trace/sample-rate 10}
              (trace/child-attrs
                {::trace/trace-id "trace123"
                 ::trace/span-id "span456"
-                ::trace/keep? false}))))))
+                ::trace/keep? false
+                ::trace/sample-rate 10}))))))
 
 
 (deftest sampling

--- a/test/ken/trace_test.clj
+++ b/test/ken/trace_test.clj
@@ -42,12 +42,12 @@
               ::trace/parent-id "span456"
               ::trace/span-id "span789"
               ::trace/keep? false
-              ::trace/upstream-sample-rate 10}
+              ::trace/upstream-sampling 10}
              (trace/child-attrs
                {::trace/trace-id "trace123"
                 ::trace/span-id "span456"
                 ::trace/keep? false
-                ::trace/upstream-sample-rate 10}))))))
+                ::trace/upstream-sampling 10}))))))
 
 
 (deftest sampling
@@ -66,11 +66,11 @@
                 ::trace/keep? true}))
           "should preserve other keys")
       (is (= {::trace/keep? false
-              ::trace/upstream-sample-rate 10}
+              ::trace/upstream-sampling 10}
              (trace/maybe-sample
                {::trace/keep? false
                 ::event/sample-rate 10}))
-          "should replace ::event/sample-rate with ::trace/upstream-sample-rate"))
+          "should replace ::event/sample-rate with ::trace/upstream-sampling"))
     (testing "event with sample rate"
       (testing "selected to keep"
         (with-redefs [trace/sample? (constantly true)]

--- a/test/ken/trace_test.clj
+++ b/test/ken/trace_test.clj
@@ -63,11 +63,12 @@
                {:foo 123
                 ::trace/keep? true}))
           "should preserve other keys")
-      (is (= {::trace/keep? false}
+      (is (= {::trace/keep? false
+              ::trace/sample-rate 10}
              (trace/maybe-sample
                {::trace/keep? false
                 ::event/sample-rate 10}))
-          "should remove sample rate"))
+          "should replace ::event/sample-rate with ::trace/sample-rate"))
     (testing "event with sample rate"
       (testing "selected to keep"
         (with-redefs [trace/sample? (constantly true)]

--- a/test/ken/trace_test.clj
+++ b/test/ken/trace_test.clj
@@ -42,12 +42,12 @@
               ::trace/parent-id "span456"
               ::trace/span-id "span789"
               ::trace/keep? false
-              ::trace/sample-rate 10}
+              ::trace/upstream-sample-rate 10}
              (trace/child-attrs
                {::trace/trace-id "trace123"
                 ::trace/span-id "span456"
                 ::trace/keep? false
-                ::trace/sample-rate 10}))))))
+                ::trace/upstream-sample-rate 10}))))))
 
 
 (deftest sampling
@@ -66,11 +66,11 @@
                 ::trace/keep? true}))
           "should preserve other keys")
       (is (= {::trace/keep? false
-              ::trace/sample-rate 10}
+              ::trace/upstream-sample-rate 10}
              (trace/maybe-sample
                {::trace/keep? false
                 ::event/sample-rate 10}))
-          "should replace ::event/sample-rate with ::trace/sample-rate"))
+          "should replace ::event/sample-rate with ::trace/upstream-sample-rate"))
     (testing "event with sample rate"
       (testing "selected to keep"
         (with-redefs [trace/sample? (constantly true)]


### PR DESCRIPTION
# Problem

Currently ken drops information about what sample rate was applied when `trace/maybe-sample` is called and the event has `::trace/keep?` set.

As a result when downstream systems receive these events they can't calculate an accurate COUNT or SUM aggregation.

# Solution

Rename ::event/sample-rate to ::trace/sample-rate when ignoring due to ::trace/keep?. Shows that the trace was downsampled, but it was applied to a parent span and the downsampling was inherited.

# Testing

Updated existing test case for maybe sample to reflect the new behavior

# Rollout

[amperity/ken-honeycomb#9](https://github.com/amperity/ken-honeycomb/pull/9) should be merged/deployed first for a clean rollout. Otherwise datasets will get a ken.trace/sample-rate field added to them