### PR TITLE
Upstream sampling to not passing through child-attrs

### DIFF
--- a/test/ken/core_test.clj
+++ b/test/ken/core_test.clj
@@ -213,18 +213,31 @@
       (let [[inner outer :as spans] @observed]
         (is (= ["inner" "outer"] (map ::event/label spans))
             "events occur in expected order")
-        (is (string? (::trace/trace-id outer))
-            "root span has a trace-id")
-        (is (apply = (map ::trace/trace-id spans))
-            "all spans share the same trace")
-        (is (= (::trace/span-id outer) (::trace/parent-id inner))
-            "inner is a child of outer")
-        (is (not= (::trace/span-id outer) (::trace/span-id inner))
-            "spans have distinct ids")
-        (is (false? (::trace/keep? outer))
-            "outer span is sampled away")
-        (is (false? (::trace/keep? inner))
-            "inner span inherits sampling decision")))))
+        (testing ":ken.trace/trace-id"
+          (is (string? (::trace/trace-id outer))
+              "root span has a trace-id")
+          (is (apply = (map ::trace/trace-id spans))
+              "all spans share the same trace"))
+        (testing ":ken.trace/span-id and :ken.trace/parent-id"
+          (is (= (::trace/span-id outer) (::trace/parent-id inner))
+              "inner is a child of outer")
+          (is (not= (::trace/span-id outer) (::trace/span-id inner))
+              "spans have distinct ids"))
+        (testing ":ken.event/sample-rate"
+          (is (= 5 (::event/sample-rate outer))
+              "outer span has sample-rate")
+          (is (nil? (::event/sample-rate inner))
+              "inner span doesn't have sample-rate"))
+        (testing ":ken.trace/upstream-sampling"
+          (is (nil? (::trace/upstream-sampling outer))
+              "outer span doesn't have upstream-sampling")
+          (is (= 5 (::trace/upstream-sampling inner))
+              "inner span has upstream-sampling"))
+        (testing ":ken.trace/keep?"
+          (is (false? (::trace/keep? outer))
+              "outer span is sampled away")
+          (is (false? (::trace/keep? inner))
+              "inner span inherits sampling decision"))))))
 
 
 ;; This test covers a specific issue that can cause incorrect span

--- a/test/ken/trace_test.clj
+++ b/test/ken/trace_test.clj
@@ -47,7 +47,17 @@
                {::trace/trace-id "trace123"
                 ::trace/span-id "span456"
                 ::trace/keep? false
-                ::trace/upstream-sampling 10}))))))
+                ::trace/upstream-sampling 10})))
+      (is (= {::trace/trace-id "trace123"
+              ::trace/parent-id "span456"
+              ::trace/span-id "span789"
+              ::trace/keep? false
+              ::trace/upstream-sampling 10}
+             (trace/child-attrs
+               {::trace/trace-id "trace123"
+                ::trace/span-id "span456"
+                ::trace/keep? false
+                ::event/sample-rate 10}))))))
 
 
 (deftest sampling
@@ -65,12 +75,11 @@
                {:foo 123
                 ::trace/keep? true}))
           "should preserve other keys")
-      (is (= {::trace/keep? false
-              ::trace/upstream-sampling 10}
+      (is (= {::trace/keep? false}
              (trace/maybe-sample
                {::trace/keep? false
                 ::event/sample-rate 10}))
-          "should replace ::event/sample-rate with ::trace/upstream-sampling"))
+          "should dissoc ::event/sample-rate"))
     (testing "event with sample rate"
       (testing "selected to keep"
         (with-redefs [trace/sample? (constantly true)]


### PR DESCRIPTION
Papercut due to not testing in ken.core in initial PR. There is a select-keys in `current-data` that was preventing sampling info being available when calling `child-attrs`. 

I took the opportunity to also make the code a bit more elegant, I moved the conversion from `::event/sample-rate` into `::trace/upstream-sampling` into `child-attrs`. Seems like a more idiomatic place to put this.

## Testing

1. Added test case in `core_test.clj` for nested watch statements with a sample rate applied. (also added `testing` blocks to organize the wall of `is` statements)
2. Updated existing test cases